### PR TITLE
fix(ksu-service): 修复文件路径中包含空格时的命令执行问题

### DIFF
--- a/webui/src/services/ksu-service.js
+++ b/webui/src/services/ksu-service.js
@@ -113,13 +113,13 @@ export class KSUService {
 
     // 读取配置文件（从 outbounds 目录）
     static async readConfig(filename) {
-        return await this.exec(`cat ${this.MODULE_PATH}/config/xray/outbounds/${filename}`);
+        return await this.exec(`cat '${this.MODULE_PATH}/config/xray/outbounds/${filename}'`);
     }
 
     // 保存配置文件（到 outbounds 目录）
     static async saveConfig(filename, content) {
         const escaped = content.replace(/'/g, "'\\''");
-        await this.exec(`echo '${escaped}' > ${this.MODULE_PATH}/config/xray/outbounds/${filename}`);
+        await this.exec(`echo '${escaped}' > '${this.MODULE_PATH}/config/xray/outbounds/${filename}'`);
     }
 
     // 从节点链接导入配置


### PR DESCRIPTION
在读取和保存配置文件时，为文件路径添加单引号以避免路径中包含空格导致命令执行失败