### PR TITLE
feat: 添加路由模式切换(global/rules)和WebUI代理开关自动重启

### DIFF
--- a/NetProxy-Module/config/routing.conf
+++ b/NetProxy-Module/config/routing.conf
@@ -1,4 +1,7 @@
 # 路由规则设置
+# 路由模式: global=全局代理, rules=规则分流
+MODE=rules
+
 GOOGLE_CN=1
 BLOCK_UDP443=1
 BLOCK_ADS=1

--- a/NetProxy-Module/scripts/cli
+++ b/NetProxy-Module/scripts/cli
@@ -94,7 +94,7 @@ cmd_status() {
         echo "进程 PID: $pid"
         
         # 尝试获取运行时间
-        local uptime=$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ' || echo "--")
+        local uptime=$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' \n' || echo "--")
         echo "运行时间: $uptime"
         
         # 内存占用
@@ -115,6 +115,14 @@ cmd_status() {
             echo "当前配置: $(basename "$config")"
         fi
     fi
+    
+    # 路由模式
+    local routing_mode="rules"
+    if [ -f "$CONFIG_DIR/routing.conf" ]; then
+        routing_mode=$(grep "^MODE=" "$CONFIG_DIR/routing.conf" 2>/dev/null | cut -d'=' -f2)
+        [ -z "$routing_mode" ] && routing_mode="rules"
+    fi
+    echo "路由模式: $routing_mode"
     
     # 代理模式
     local mode="blacklist"
@@ -682,6 +690,35 @@ cmd_proxy() {
 }
 
 #######################################
+# 路由模式管理
+#######################################
+cmd_routing() {
+    local subcmd="${1:-}"
+    shift 2>/dev/null || true
+    
+    case "$subcmd" in
+        mode)
+            local mode="${1:-}"
+            if [ -z "$mode" ]; then
+                # 查看当前模式
+                sh "$SCRIPTS_DIR/network/routing.sh" mode
+            else
+                # 设置模式
+                sh "$SCRIPTS_DIR/network/routing.sh" mode "$mode"
+            fi
+            ;;
+        *)
+            echo "用法: cli routing <命令>"
+            echo ""
+            echo "命令:"
+            echo "  mode              查看路由模式"
+            echo "  mode global       全局代理（所有流量走代理）"
+            echo "  mode rules        规则分流（广告阻断、中国直连等）"
+            ;;
+    esac
+}
+
+#######################################
 # 显示帮助
 #######################################
 show_help() {
@@ -719,6 +756,11 @@ NetProxy CLI - 命令行控制工具
   proxy remove <包名> 从列表移除应用
   proxy reload        重载代理规则
 
+路由模式:
+  routing mode        查看路由模式
+  routing mode global 全局代理（所有流量走代理）
+  routing mode rules  规则分流（广告阻断、中国直连等）
+
 示例:
   # 服务控制
   adb shell su -c "/data/adb/modules/netproxy/scripts/cli status"
@@ -749,6 +791,11 @@ NetProxy CLI - 命令行控制工具
   adb shell su -c "/data/adb/modules/netproxy/scripts/cli proxy add com.google.android.youtube"
   adb shell su -c "/data/adb/modules/netproxy/scripts/cli proxy remove com.google.android.youtube"
   adb shell su -c "/data/adb/modules/netproxy/scripts/cli proxy reload"
+
+  # 路由模式
+  adb shell su -c "/data/adb/modules/netproxy/scripts/cli routing mode"
+  adb shell su -c "/data/adb/modules/netproxy/scripts/cli routing mode global"
+  adb shell su -c "/data/adb/modules/netproxy/scripts/cli routing mode rules"
 
 EOF
 }
@@ -781,6 +828,9 @@ main() {
             ;;
         proxy)
             cmd_proxy "$@"
+            ;;
+        routing)
+            cmd_routing "$@"
             ;;
         -h|--help|help|"")
             show_help

--- a/NetProxy-Module/scripts/network/routing.sh
+++ b/NetProxy-Module/scripts/network/routing.sh
@@ -3,6 +3,9 @@
 #############################################################################
 # 路由规则管理脚本
 # 功能: 读取/设置路由开关，生成 routing.json
+# 支持两种路由模式:
+#   - global: 全局代理模式，所有流量走代理（内网除外）
+#   - rules:  规则模式，按分流规则处理（广告阻断、中国直连等）
 #############################################################################
 
 set -e
@@ -11,6 +14,57 @@ set -u
 readonly MODDIR="$(cd "$(dirname "$0")/../.." && pwd)"
 readonly SETTINGS_FILE="$MODDIR/config/routing.conf"
 readonly ROUTING_FILE="$MODDIR/config/xray/confdir/03_routing.json"
+
+#######################################
+# 获取当前路由模式
+# Returns: global 或 rules
+#######################################
+get_mode() {
+    local mode
+    mode=$(grep "^MODE=" "$SETTINGS_FILE" 2>/dev/null | cut -d'=' -f2)
+    case "$mode" in
+        global|rules) echo "$mode" ;;
+        *) echo "rules" ;;
+    esac
+}
+
+#######################################
+# 设置路由模式
+# Arguments:
+#   $1 - mode (global/rules)
+#######################################
+cmd_mode() {
+    local mode="${1:-}"
+    
+    if [ -z "$mode" ]; then
+        echo "当前路由模式: $(get_mode)"
+        return 0
+    fi
+    
+    case "$mode" in
+        global|rules)
+            if grep -q "^MODE=" "$SETTINGS_FILE" 2>/dev/null; then
+                sed -i "s/^MODE=.*/MODE=${mode}/" "$SETTINGS_FILE"
+            else
+                echo "MODE=${mode}" >> "$SETTINGS_FILE"
+            fi
+            echo "已切换到 $mode 模式"
+            cmd_apply
+            # 重启 Xray 使配置生效
+            if pgrep -f "xray" >/dev/null 2>&1; then
+                echo "正在重启服务..."
+                sh "$MODDIR/scripts/core/stop.sh" >/dev/null 2>&1
+                sh "$MODDIR/scripts/core/start.sh" >/dev/null 2>&1
+                echo "服务已重启"
+            fi
+            ;;
+        *)
+            echo "错误: 无效的模式 '$mode'"
+            echo "可用模式: global (全局代理), rules (规则分流)"
+            return 1
+            ;;
+    esac
+}
 
 #######################################
 # 读取设置 (返回 JSON 格式给 WebUI)
@@ -29,9 +83,15 @@ cmd_get() {
             \#*|"") continue ;;
         esac
         key=$(echo "$key" | tr '[:upper:]' '[:lower:]')
-        [ "$value" = "1" ] && value="true" || value="false"
-        [ "$first" = "true" ] && first=false || echo ','
-        printf '    "%s": %s' "$key" "$value"
+        # MODE 是字符串，其他是布尔值
+        if [ "$key" = "mode" ]; then
+            [ "$first" = "true" ] && first=false || echo ','
+            printf '    "%s": "%s"' "$key" "$value"
+        else
+            [ "$value" = "1" ] && value="true" || value="false"
+            [ "$first" = "true" ] && first=false || echo ','
+            printf '    "%s": %s' "$key" "$value"
+        fi
     done < "$SETTINGS_FILE"
     echo
     echo '}'
@@ -78,11 +138,43 @@ get_setting() {
 }
 
 #######################################
-# 生成路由配置
+# 生成全局模式路由配置
 #######################################
-cmd_apply() {
-    echo "正在生成路由配置..."
-    
+generate_global_routing() {
+    cat > "$ROUTING_FILE" << 'EOF'
+{
+    "routing": {
+        "domainStrategy": "AsIs",
+        "rules": [
+            {
+                "type": "field",
+                "ip": [
+                    "geoip:private"
+                ],
+                "outboundTag": "direct"
+            },
+            {
+                "type": "field",
+                "domain": [
+                    "geosite:private"
+                ],
+                "outboundTag": "direct"
+            },
+            {
+                "type": "field",
+                "port": "0-65535",
+                "outboundTag": "proxy"
+            }
+        ]
+    }
+}
+EOF
+}
+
+#######################################
+# 生成规则模式路由配置
+#######################################
+generate_rules_routing() {
     # 开始 JSON
     cat > "$ROUTING_FILE" << 'EOF'
 {
@@ -300,7 +392,28 @@ EOF
     }
 }
 EOF
+}
 
+#######################################
+# 生成路由配置（根据当前模式）
+#######################################
+cmd_apply() {
+    local mode="$(get_mode)"
+    echo "正在生成路由配置 (模式: $mode)..."
+    
+    case "$mode" in
+        global)
+            generate_global_routing
+            ;;
+        rules)
+            generate_rules_routing
+            ;;
+        *)
+            echo "警告: 未知模式 '$mode'，使用规则模式"
+            generate_rules_routing
+            ;;
+    esac
+    
     echo "路由配置已生成: $ROUTING_FILE"
 }
 
@@ -308,10 +421,20 @@ EOF
 # 主程序
 #######################################
 case "${1:-}" in
+    mode)
+        cmd_mode "${2:-}"
+        ;;
     get)
         cmd_get
         ;;
     set)
+        # set 命令只在 rules 模式下生效
+        if [ "$(get_mode)" != "rules" ]; then
+            echo "错误: set 命令仅在 rules 模式下有效"
+            echo "当前模式: $(get_mode)"
+            echo "请先执行: $0 mode rules"
+            exit 1
+        fi
         cmd_set "$2" "$3"
         cmd_apply
         ;;
@@ -319,10 +442,18 @@ case "${1:-}" in
         cmd_apply
         ;;
     *)
-        echo "用法: $0 {get|set|apply}"
+        echo "用法: $0 {mode|get|set|apply}"
+        echo ""
+        echo "命令:"
+        echo "  mode             查看当前路由模式"
+        echo "  mode <模式>      切换路由模式 (global/rules)"
         echo "  get              获取当前设置"
-        echo "  set <key> <val>  设置某项 (true/false)"
+        echo "  set <key> <val>  设置某项 (true/false，仅规则模式)"
         echo "  apply            应用设置生成 routing.json"
+        echo ""
+        echo "路由模式:"
+        echo "  global  全局代理，所有流量走代理（内网除外）"
+        echo "  rules   规则分流，按配置的规则处理"
         exit 1
         ;;
 esac

--- a/webui/src/services/ksu-service.js
+++ b/webui/src/services/ksu-service.js
@@ -829,6 +829,9 @@ export class KSUService {
         const upperKey = key.toUpperCase();
         const numValue = value ? '1' : '0';
         await this.exec(`sed -i 's/${upperKey}=.*/${upperKey}=${numValue}/' ${this.MODULE_PATH}/config/tproxy.conf`);
+        // 重启服务使 iptables 规则生效
+        await this.exec(`sh ${this.MODULE_PATH}/scripts/core/stop.sh`);
+        await this.exec(`sh ${this.MODULE_PATH}/scripts/core/start.sh`);
         return { success: true };
     }
 


### PR DESCRIPTION
- routing.sh: 支持 global(全局代理) 和 rules(规则分流) 两种模式
- routing.conf: 添加 MODE 配置项
- cli: 添加 routing 命令，status 显示路由模式，修复运行时间换行
- ksu-service.js: 修改代理开关后自动重启服务使 iptables 规则生效

全局模式: 所有流量走代理，仅 localhost/内网除外
规则模式: 按配置的规则处理（广告阻断、中国直连等）