### PR TITLE
style(webui): 调整主题切换按钮边距并禁用导航栏激活项效果

### DIFF
--- a/webui/src/index.html
+++ b/webui/src/index.html
@@ -156,7 +156,7 @@
       <div style="width: 24px"></div>
       <mdui-top-app-bar-title>NetProxy</mdui-top-app-bar-title>
       <div style="flex-grow: 1"></div>
-      <mdui-button-icon icon="brightness_6" id="theme-toggle"></mdui-button-icon>
+      <mdui-button-icon icon="brightness_6" id="theme-toggle" style="margin-right: 20px;"></mdui-button-icon>
     </mdui-top-app-bar>
 
     <!-- Main Content -->

--- a/webui/src/styles/components/mdui-overrides.css
+++ b/webui/src/styles/components/mdui-overrides.css
@@ -46,6 +46,22 @@ mdui-navigation-bar-item[active]::part(label) {
   color: var(--monet-on-secondary-container, var(--mdui-color-on-secondary-container)) !important;
 }
 
+/* 导航栏项目 - 激活状态禁用涟漪和状态层效果 */
+mdui-navigation-bar-item[active] {
+  /* 禁用所有状态层透明度 */
+  --mdui-state-layer-hover: 0 !important;
+  --mdui-state-layer-focus: 0 !important;
+  --mdui-state-layer-pressed: 0 !important;
+  --mdui-state-layer-dragged: 0 !important;
+}
+
+mdui-navigation-bar-item[active]::part(ripple),
+mdui-navigation-bar-item[active]::part(state-layer) {
+  display: none !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+}
+
 /* ==================== 按钮 ==================== */
 
 mdui-button {


### PR DESCRIPTION
调整主题切换按钮的右边距以改善布局，同时禁用导航栏激活项的状态层和涟漪效果以提升视觉一致性