### PR TITLE
fix(webui): 修改当前标签文字颜色并移除未使用的依赖

### DIFF
--- a/src/webui/package-lock.json
+++ b/src/webui/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "kernelsu": "^3.0.0",
-        "mdui": "^2.1.4",
-        "webuix": "^0.0.18"
+        "mdui": "^2.1.4"
       },
       "devDependencies": {
         "parcel": "^2.16.3"
@@ -3192,20 +3191,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
@@ -3253,15 +3238,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webuix": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/webuix/-/webuix-0.0.18.tgz",
-      "integrity": "sha512-WbQAN+aFS7Yt/ga0fV1X1Ip68ZszAWm7zkJGSzPued7vG/DYfRnyKKEbxK6PqYE261CSHym7E7gU2Xgs7jSpGA==",
-      "license": "GPL-3.0-only",
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      }
     }
   }
 }

--- a/src/webui/src/ui/config-page.js
+++ b/src/webui/src/ui/config-page.js
@@ -467,7 +467,7 @@ export class ConfigPageManager {
         if (isCurrent) {
             const currentTag = document.createElement('span');
             currentTag.textContent = I18nService.t('config.status.current');
-            currentTag.style.cssText = 'font-size: 10px; padding: 1px 4px; border-radius: 4px; background: var(--mdui-color-primary); color: var(--mdui-color-on-surface-variant);';
+            currentTag.style.cssText = 'font-size: 10px; padding: 1px 4px; border-radius: 4px; background: var(--mdui-color-primary); color: #ffffff;';
             protocolLine.appendChild(currentTag);
         }
 


### PR DESCRIPTION
移除webuix和typescript依赖项，这些依赖不再需要
将当前标签文字颜色从--mdui-color-on-surface-variant改为#ffffff以提高可读性