### PR TITLE
fix(webui): 修复代理模式切换时的事件处理问题

### DIFF
--- a/src/webui/src/ui/uid-page.js
+++ b/src/webui/src/ui/uid-page.js
@@ -25,7 +25,7 @@ export class UIDPageManager {
         if (modeGroup) {
             modeGroup.addEventListener('change', async (e) => {
                 if (this.isUpdatingUI) return;
-                const newMode = e.target.value;
+                const newMode = modeGroup.value;
                 await this.handleProxyModeChange(newMode);
             });
         }
@@ -248,7 +248,7 @@ export class UIDPageManager {
                 this.proxyMode = modeValue;
                 toast(I18nService.t('uid.toast_mode_switched') + (modeValue === 'blacklist' ? I18nService.t('uid.mode_blacklist') : I18nService.t('uid.mode_whitelist')));
             }
-            this.update();
+            this.update(true);
         } catch (error) {
             toast(I18nService.t('common.set_failed') + error.message, true);
         }


### PR DESCRIPTION
使用modeGroup.value替代e.target.value获取当前选中值，确保模式切换时获取正确的值 同时更新handleProxyModeChange调用后的刷新逻辑，强制刷新界面