### PR TITLE
fix(webui): 修复网络检测图标刷新问题

### DIFF
--- a/src/webui/src/ui/status-page.ts
+++ b/src/webui/src/ui/status-page.ts
@@ -449,7 +449,15 @@ export class StatusPageManager {
                 if (iconEl) {
                     if (ipInfo) {
                         const flag = countryCodeToEmoji(ipInfo.countryCode);
-                        iconEl.outerHTML = `<span class="flag-icon twemoji">${flag}</span>`;
+                        if (
+                            iconEl instanceof HTMLElement &&
+                            iconEl.tagName.toLowerCase() === 'span'
+                        ) {
+                            iconEl.className = 'flag-icon twemoji';
+                            iconEl.textContent = flag;
+                        } else {
+                            iconEl.outerHTML = `<span id="network-detection-icon" class="flag-icon twemoji">${flag}</span>`;
+                        }
                     } else {
                         iconEl.outerHTML = `<mdui-icon name="network_check" class="card-icon" id="network-detection-icon"></mdui-icon>`;
                     }


### PR DESCRIPTION
当检测到IP信息时，现在会检查iconEl是否为HTMLElement且标签为span，如果是则直接修改其属性和内容，否则使用outerHTML替换。这解决了在某些情况下图标刷新的问题