### PR TITLE
弃用fakeipDNS

### DIFF
--- a/src/module/config/singbox/confdir/03_dns.json
+++ b/src/module/config/singbox/confdir/03_dns.json
@@ -128,17 +128,9 @@
         ],
         "action": "route",
         "server": "dns-direct"
-      },
-      {
-        "query_type": [
-          "A",
-          "AAAA"
-        ],
-        "action": "route",
-        "server": "remote"
       }
     ],
-    "final": "dns-direct",
+    "final": "dns-proxy",
     "optimistic": true,
     "strategy": "prefer_ipv4"
   }


### PR DESCRIPTION
安卓 dns 请求的特殊性，fakeip会与黑白名单冲突