### PR TITLE
docs: 修复 README 星标图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,4 +298,4 @@ su -c '/data/adb/modules/netproxy/netproxyctl logs export /sdcard/Download/netpr
 
 ## Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fanju6/NetProxy-Magisk&type=date&legend=top-left)](https://www.star-history.com/#Fanju6/NetProxy-Magisk&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fanju6/NetProxy-Magisk&type=date&legend=top-left)](https://star-history.dera.page/#Fanju6/NetProxy-Magisk&type=date&legend=top-left)

--- a/README_EN.md
+++ b/README_EN.md
@@ -284,4 +284,4 @@ The following projects powered or inspired earlier NetProxy releases. Their cont
 
 ## Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Fanju6/NetProxy-Magisk&type=date&legend=top-left)](https://www.star-history.com/#Fanju6/NetProxy-Magisk&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Fanju6/NetProxy-Magisk&type=date&legend=top-left)](https://star-history.dera.page/#Fanju6/NetProxy-Magisk&type=date&legend=top-left)


### PR DESCRIPTION
当前 README 中的星标历史图表已无法加载，原因是原有图表服务受 GitHub stargazer API 限制而失效。本修改将 README 与 README_EN 中的图表切换到可用的新渲染服务并同步更新包裹链接，恢复星标历史图表的正常展示。