### PR TITLE
chore(维护): 更新 sing-box 内核

### DIFF
--- a/.github/resources.json
+++ b/.github/resources.json
@@ -59,7 +59,7 @@
     "path": "src/module/bin/sing-box",
     "repo": "reF1nd/sing-box",
     "tagPattern": "^v[0-9].*-reF1nd$",
-    "currentVersion": "v1.14.0-beta.14-reF1nd",
+    "currentVersion": "v1.14.0-beta.15-reF1nd",
     "buildTags": [
       "with_quic",
       "with_utls",


### PR DESCRIPTION
## 每周自动更新

本 PR 由[每周更新资源、内核与依赖](https://github.com/Fanju6/NetProxy-Magisk/actions/workflows/update-resources.yml)工作流自动生成。

本次更新 **1 个分类、1 项内容**。

### 更新概览

| 分类 | 更新结果 |
| --- | --- |
| 规则资源 | 无更新 |
| Web 面板 | 无更新 |
| sing-box 内核 | 1 个版本 |
| npm 依赖 | 无更新 |
| Android 依赖 | 无更新 |
| GitHub Actions | 无更新 |

### 更新详情

#### sing-box 内核

- 版本：[v1.14.0-beta.14-reF1nd → v1.14.0-beta.15-reF1nd](https://github.com/reF1nd/sing-box/compare/v1.14.0-beta.14-reF1nd...v1.14.0-beta.15-reF1nd)
- 二进制大小：53.14 MiB → 62.50 MiB
- SHA-256：`51072e3437e318f4de588689f8a9daa28544338acfef66e0d89dc3f65bd4d76e`
- 构建标签：`with_quic`、`with_utls`、`with_clash_api`、`with_gvisor`、`with_tailscale`、`badlinkname`、`tfogo_checklinkname0`、`with_ebpf`、`with_connection_history`
- 构建检查：ARM64 架构、版本信息匹配、包含 eBPF、包含 Tailscale、已同步 JSON Schema

### 验证结果

- 文档站构建通过
- WebUI 构建通过
- Git 差异检查通过
- 依赖与 PR 报告脚本检查通过

> 合并后将触发 CI 重新构建打包；请先核对 diff 是否符合预期。
