### PR TITLE
fix(module): 命中 WiFi 黑名单时关闭 DNS 劫持

### DIFF
--- a/src/native/netproxy/internal/module/app.go
+++ b/src/native/netproxy/internal/module/app.go
@@ -111,6 +111,10 @@ func Prepare(ctx context.Context, options Options, allowEmpty bool) (PrepareResu
 	if err != nil {
 		return PrepareResult{}, err
 	}
+	if readWiFiState(options.WiFiStateFile) == "bypassed" {
+		config.Local.DNSMode = "off"
+		config.Shared.DNSMode = "off"
+	}
 	missingPackages, err := ebpf.WriteAtomic(ctx, ebpfPath, config)
 	if err != nil {
 		return PrepareResult{}, err

--- a/src/native/netproxy/internal/module/network.go
+++ b/src/native/netproxy/internal/module/network.go
@@ -96,6 +96,7 @@ func EvaluateNetwork(ctx context.Context, options Options, networkType, ssid str
 		result.Reason = "网络策略未变化"
 		return result, nil
 	}
+	targetChanged := previousState != target
 	modeChanged := result.RuntimeMode != modeToRuntime(desiredMode)
 	if modeChanged {
 		if service.ProcessRunning(options.SingBoxPath) {
@@ -109,7 +110,12 @@ func EvaluateNetwork(ctx context.Context, options Options, networkType, ssid str
 	if err := writeWiFiState(options.WiFiStateFile, target); err != nil {
 		return result, err
 	}
-	result.Changed = previousState != target || modeChanged
+	if targetChanged && service.ProcessRunning(options.SingBoxPath) {
+		if err := ReloadService(ctx, options); err != nil {
+			return result, err
+		}
+	}
+	result.Changed = targetChanged || modeChanged
 	if target == "bypassed" {
 		result.Reason = "已切换为绕过代理"
 	} else {


### PR DESCRIPTION
## 问题

命中 WiFi 黑名单（`WIFI_SSID_MODE=blacklist` 且当前 SSID 在 `WIFI_SSID_LIST` 中）时，模块会把出站模式切为 `direct`、流量绕过代理，但 eBPF 的 DNS 劫持（`EBPF_LOCAL_DNS_MODE=hijack`）没有同步关闭，导致 DNS 仍被劫持到 DoH（`dns-direct`），而不是使用该 WiFi 的 DNS（走系统 netd）。

期望行为：命中黑名单 → 流量直连 + DNS 也切到该 WiFi 自身 DNS（不再劫持）。

## 根因

`internal/module/network.go` 的 `EvaluateNetwork` 只调用了 `ApplyRuntimeMode`（切 clash 模式），没有联动 eBPF 的 `dns_mode`。

## 修复

1. `internal/module/app.go`（`Prepare`）：生成 `runtime/ebpf.json` 时读取 WiFi 状态文件，状态为 `bypassed` 时把 `Local.DNSMode`/`Shared.DNSMode` 临时覆盖为 `off`（不改写用户的 `ebpf.conf`）。
2. `internal/module/network.go`（`EvaluateNetwork`）：`target` 在 `bypassed`↔`proxying` 之间变化时，除切换 clash 模式外再触发一次 `ReloadService`，让新的 `dns_mode` 生效。

## 验证

真机上用 `netproxyctl network evaluate` 验证：
- `--type wifi --ssid <黑名单SSID>` → `runtime/ebpf.json` 的 `dns_mode` 变为 `off`；
- `--type not_wifi` → 恢复为 `hijack`。

此修复对所有黑名单 WiFi 生效，不针对某个特定 SSID。